### PR TITLE
Hotfix : Exclude Non Searchable Columns From Search Query

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "datatable",
         "laravel"
     ],
-    "version": "4.1",
+    "version": "4.2",
     "license": "MIT",
     "authors": [{
         "name": "Yogesh Sharma",

--- a/src/Traits/HasQueryBuilder.php
+++ b/src/Traits/HasQueryBuilder.php
@@ -283,7 +283,7 @@ trait HasQueryBuilder
                     if (!$globalSearch || in_array(explode('.', $columnName)[1], $this->globalSearchColumns, true)) {
                         $this->whereColumns[] =  [trim($columnName), $search];
                     }
-                } else {
+                } elseif (!$globalSearch || in_array( $columnName, $this->globalSearchColumns, true)) {
                     $this->whereColumns[] = [trim($columnName), $search];
                 }
             }

--- a/src/Traits/HasQueryBuilder.php
+++ b/src/Traits/HasQueryBuilder.php
@@ -270,22 +270,22 @@ trait HasQueryBuilder
                     $this->havingColumns[] = [trim($column[1]), $search];
                 }
             }
+        } 
+        elseif (strpos($columnName, ' as ')) {
+            $column = explode(' as ',$columnName);
+            if (!$globalSearch || in_array(trim($column[1]), $this->globalSearchColumns, true)) {
+                $this->whereColumns[] = [trim($column[0]), $search];
+            }
+
         }
         elseif (!strpos($columnName, '_id')) {
-            if (strpos($columnName, ' as ')) {
-                $column = explode(' as ',$columnName);
-                if (!$globalSearch || in_array(trim($column[1]), $this->globalSearchColumns, true)) {
-                    $this->whereColumns[] = [trim($column[0]), $search];
+            if (isset(explode('.', $columnName)[1])) {
+                if (!$globalSearch || in_array(explode('.', $columnName)[1], $this->globalSearchColumns, true)) {
+                    $this->whereColumns[] =  [trim($columnName), $search];
                 }
-
-            } else {
-                if (isset(explode('.', $columnName)[1])) {
-                    if (!$globalSearch || in_array(explode('.', $columnName)[1], $this->globalSearchColumns, true)) {
-                        $this->whereColumns[] =  [trim($columnName), $search];
-                    }
-                } elseif (!$globalSearch || in_array( $columnName, $this->globalSearchColumns, true)) {
-                    $this->whereColumns[] = [trim($columnName), $search];
-                }
+            } 
+            elseif (!$globalSearch || in_array( $columnName, $this->globalSearchColumns, true)) {
+                $this->whereColumns[] = [trim($columnName), $search];
             }
         }
     }


### PR DESCRIPTION
This PR introduces a quick fix for a bug where all columns were still being checked in the search query, even after setting searchable to false. This issue occurred when the column name did not include an alias (AS) or a table name prefix.